### PR TITLE
Fix #12 properly

### DIFF
--- a/projects/core/bindaas-core-impl/src/main/java/edu/emory/cci/bindaas/core/apikey/impl/DefaultAPIKeyManager.java
+++ b/projects/core/bindaas-core-impl/src/main/java/edu/emory/cci/bindaas/core/apikey/impl/DefaultAPIKeyManager.java
@@ -23,6 +23,8 @@ import edu.emory.cci.bindaas.core.model.hibernate.UserRequest;
 import edu.emory.cci.bindaas.core.model.hibernate.UserRequest.Stage;
 import edu.emory.cci.bindaas.security.api.BindaasUser;
 
+import static edu.emory.cci.bindaas.core.rest.security.SecurityHandler.invalidateAPIKey;
+
 public class DefaultAPIKeyManager implements IAPIKeyManager {
 
 	private Log log = LogFactory.getLog(getClass());
@@ -248,6 +250,10 @@ public class DefaultAPIKeyManager implements IAPIKeyManager {
 					usrRequest.setStage(Stage.revoked);
 				}
 				session.getTransaction().commit();
+				for (UserRequest request: listOfValidKeys) {
+					String apiKey = request.getApiKey();
+					invalidateAPIKey(apiKey);
+				}
 				return listOfValidKeys.size();
 			}
 			else
@@ -282,6 +288,7 @@ public class DefaultAPIKeyManager implements IAPIKeyManager {
 					usrRequest.setStage(Stage.revoked);
 				}
 				session.getTransaction().commit();
+				invalidateAPIKey(apiKey);
 				return listOfValidKeys.size();
 			}
 			else
@@ -398,6 +405,7 @@ public class DefaultAPIKeyManager implements IAPIKeyManager {
 				for(HistoryLog histLog : historyLogs)
 					session.delete(histLog);
 				session.delete(usr);
+				invalidateAPIKey(usr.getApiKey()); //delete any API keys still present in the cache.
 			}
 			session.getTransaction().commit();
 			int rowsDeleted = list.size(); 

--- a/projects/core/bindaas-core-impl/src/main/java/edu/emory/cci/bindaas/core/rest/security/SecurityHandler.java
+++ b/projects/core/bindaas-core-impl/src/main/java/edu/emory/cci/bindaas/core/rest/security/SecurityHandler.java
@@ -126,8 +126,8 @@ public class SecurityHandler implements RequestHandler,ISecurityHandler {
 
 	private static void initCache() {
 		// initialize caches
-		authenticationDecisionCache = CacheBuilder.newBuilder().expireAfterAccess(DECISION_CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES).maximumSize(DECISION_CACHE_MAX).build();
-		authorizationDecisionCache = CacheBuilder.newBuilder().expireAfterAccess(DECISION_CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES).maximumSize(DECISION_CACHE_MAX).build();
+		authenticationDecisionCache = CacheBuilder.newBuilder().expireAfterWrite(DECISION_CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES).maximumSize(DECISION_CACHE_MAX).build();
+		authorizationDecisionCache = CacheBuilder.newBuilder().expireAfterWrite(DECISION_CACHE_TIMEOUT_MINUTES, TimeUnit.MINUTES).maximumSize(DECISION_CACHE_MAX).build();
 	}
 
 	private Principal handleHTTP_BASIC(Message message , IAuthenticationProvider authenticationProvider) throws Exception

--- a/projects/core/bindaas-web-console/src/main/java/edu/emory/cci/bindaas/webconsole/admin/UserManagementPanelAction.java
+++ b/projects/core/bindaas-web-console/src/main/java/edu/emory/cci/bindaas/webconsole/admin/UserManagementPanelAction.java
@@ -20,6 +20,8 @@ import edu.emory.cci.bindaas.core.model.hibernate.UserRequest.Stage;
 import edu.emory.cci.bindaas.framework.util.GSONUtil;
 import edu.emory.cci.bindaas.security.api.BindaasUser;
 
+import static edu.emory.cci.bindaas.core.rest.security.SecurityHandler.invalidateAPIKey;
+
 public class UserManagementPanelAction implements IAdminAction {
 	
 	private String actionName;
@@ -70,6 +72,7 @@ public class UserManagementPanelAction implements IAdminAction {
 		else if(requestObject.entityAction!=null && requestObject.entityAction.equals(ActivityType.REVOKE.toString()) )
 		{
 			APIKey apiKey = this.apiKeyManager.modifyAPIKey(requestObject.entityId, Stage.revoked, requestObject.getExpiration(), admin.getName(), requestObject.entityComments, ActivityType.REVOKE );
+			invalidateAPIKey(apiKey.getValue());
 			emailMessage = "Your access has been revoked by the administrator";
 			emailAddress = apiKey.getEmailAddress();
 			

--- a/projects/core/bindaas-web-console/src/main/java/edu/emory/cci/bindaas/webconsole/servlet/action/ManageUserRegistration.java
+++ b/projects/core/bindaas-web-console/src/main/java/edu/emory/cci/bindaas/webconsole/servlet/action/ManageUserRegistration.java
@@ -31,6 +31,8 @@ import edu.emory.cci.bindaas.webconsole.AbstractRequestHandler;
 import edu.emory.cci.bindaas.webconsole.ErrorView;
 import edu.emory.cci.bindaas.webconsole.util.VelocityEngineWrapper;
 
+import static edu.emory.cci.bindaas.core.rest.security.SecurityHandler.invalidateAPIKey;
+
 
 public class ManageUserRegistration extends AbstractRequestHandler {
 
@@ -193,8 +195,7 @@ public class ManageUserRegistration extends AbstractRequestHandler {
 						{
 							userRequest.setStage("revoked");
 							emailMessage = "Your access has been revoked by the administrator";
-							
-							
+							invalidateAPIKey(userRequest.getApiKey());
 						}
 						else if(requestObject.entityAction!=null && requestObject.entityAction.equals("deny") )
 						{


### PR DESCRIPTION
1. Invalidate the api key from cache when,
1.1. A user is deleted using the trusted app management.
1.2. A key is revoked from the admin dashboard.

2. Expire cache after 6 minutes, rather than 60 minutes or 1 minute. A middle ground. A trade-off of performance vs security.

3. Use "since the last write" not "last access" to have the issue of an expired api key working forever, as long as it is being used continuously.