### PR TITLE
Support Mongo Aggregate operation

### DIFF
--- a/distribution/build-configuration/version.info
+++ b/distribution/build-configuration/version.info
@@ -1,5 +1,5 @@
-#Mon, 10 Jun 2019 10:46:19 -0400
+#Tue, 18 Feb 2020 21:16:17 +0530
 bindaas.framework.version.major=4
 bindaas.framework.version.minor=0
-bindaas.framework.version.revision=0
-bindaas.build.date=201909051046
+bindaas.framework.version.revision=7
+bindaas.build.date=202002182116

--- a/projects/plugins/data_providers/mongodb-datasource-provider/src/main/java/edu/emory/cci/bindaas/datasource/provider/mongodb/operation/AggregateOperationHandler.java
+++ b/projects/plugins/data_providers/mongodb-datasource-provider/src/main/java/edu/emory/cci/bindaas/datasource/provider/mongodb/operation/AggregateOperationHandler.java
@@ -1,0 +1,127 @@
+package edu.emory.cci.bindaas.datasource.provider.mongodb.operation;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.annotations.Expose;
+import com.mongodb.*;
+import com.mongodb.util.JSON;
+import edu.emory.cci.bindaas.datasource.provider.mongodb.MongoDBProvider;
+import edu.emory.cci.bindaas.datasource.provider.mongodb.model.OutputFormatProps;
+import edu.emory.cci.bindaas.datasource.provider.mongodb.outputformat.OutputFormatRegistry;
+import edu.emory.cci.bindaas.framework.model.ProviderException;
+import edu.emory.cci.bindaas.framework.model.QueryResult;
+import edu.emory.cci.bindaas.framework.util.GSONUtil;
+import edu.emory.cci.bindaas.framework.util.StandardMimeType;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static edu.emory.cci.bindaas.datasource.provider.mongodb.MongoDBProvider.getAuthorizationRulesCache;
+
+public class AggregateOperationHandler implements IOperationHandler
+{
+    private Log log = LogFactory.getLog(getClass());
+
+    @Override
+    public QueryResult handleOperation(DBCollection collection,
+                                       OutputFormatProps outputFormatProps, JsonObject operationArguments , OutputFormatRegistry registry, Object role, boolean authorization)
+            throws ProviderException {
+        AggregateOperationHandler.AggregateOperationDescriptor operationDescriptor = GSONUtil.getGSONInstance().fromJson(operationArguments, AggregateOperationHandler.AggregateOperationDescriptor.class);
+        validateArguments(operationDescriptor);
+
+        try{
+            DBObject match = (DBObject) JSON.parse(operationDescriptor.match.toString());
+            DBObject group = operationDescriptor.group == null ? null : (DBObject) JSON.parse(operationDescriptor.group.toString());
+            DBObject sort = operationDescriptor.sort == null ? null : (DBObject) JSON.parse(operationDescriptor.sort.toString());
+
+
+            DBCursor cursor = collection.find(match);
+            if(role != null & authorization) {
+                for(DBObject o : cursor) {
+                    if(!getAuthorizationRulesCache().getIfPresent(role.toString()).
+                            contains(o.get("project").toString())){
+                        throw new ProviderException(MongoDBProvider.class.getName() , MongoDBProvider.VERSION, "Not authorized to execute this query.");
+                    }
+                }
+            }
+            DBObject matchobj = new BasicDBObject("$match", match);
+            DBObject groupobj = new BasicDBObject("$group", group);
+            DBObject sortobj = null;
+            if(sort!=null){
+                sortobj = new BasicDBObject("$sort", sort);
+            }
+            ArrayList<DBObject> pipeline = new ArrayList<DBObject>();
+            pipeline.add(matchobj);
+            pipeline.add(groupobj);
+            if(sortobj!=null){
+                pipeline.add(sortobj);
+            }
+            AggregationOutput aggregateOutput = collection.aggregate(pipeline);
+            Iterable<DBObject> result = aggregateOutput.results();
+            QueryResult queryResult = new QueryResult();
+            queryResult.setMimeType(StandardMimeType.JSON.toString());
+            queryResult.setData(new ByteArrayInputStream(result.toString().getBytes()));
+            return queryResult;
+
+        }
+        catch(Exception e)
+        {
+            log.error(e);
+            throw new ProviderException(MongoDBProvider.class.getName() , MongoDBProvider.VERSION ,e);
+        }
+    }
+
+    private  void validateArguments(AggregateOperationHandler.AggregateOperationDescriptor operationDescriptor) throws ProviderException
+    {
+        try {
+            check(operationDescriptor!=null ,"Invalid query. Arguments cannot as [AggregateOperationDescriptor]");
+            check(operationDescriptor.match!=null ,"Invalid query. AggregateOperationDescriptor missing parameter [match]");
+            check(operationDescriptor.group!=null ,"Invalid query. AggregateOperationDescriptor missing parameter [group]");
+        } catch (Exception e) {
+            log.error(e);
+            throw new ProviderException(MongoDBProvider.class.getName() , MongoDBProvider.VERSION ,e);
+        }
+
+    }
+
+    private static void check(boolean condition , String message) throws Exception
+    {
+        if(!condition) throw new Exception(message);
+    }
+
+    public static class AggregateOperationDescriptor {
+
+        @Expose public JsonObject match;
+        @Expose public JsonObject group;
+        @Expose public JsonObject sort;
+
+        public JsonObject getMatch() {
+            return match;
+        }
+
+        public void setMatch(JsonObject match) {
+            this.match = match;
+        }
+
+        public JsonObject getGroup() {
+            return group;
+        }
+
+        public void setGroup(JsonObject group) {
+            this.group = group;
+        }
+
+        public JsonObject getSort() {
+            return sort;
+        }
+
+        public void setSort(JsonObject sort) {
+            this.sort = sort;
+        }
+
+    }
+}

--- a/projects/plugins/data_providers/mongodb-datasource-provider/src/main/java/edu/emory/cci/bindaas/datasource/provider/mongodb/operation/MongoDBQueryOperationType.java
+++ b/projects/plugins/data_providers/mongodb-datasource-provider/src/main/java/edu/emory/cci/bindaas/datasource/provider/mongodb/operation/MongoDBQueryOperationType.java
@@ -3,7 +3,7 @@ package edu.emory.cci.bindaas.datasource.provider.mongodb.operation;
 public enum MongoDBQueryOperationType {
 
 	find(new FindOperationHandler()),count(new CountOperationHandler()),distinct(new DistinctOperationHandler()),
-	group(new GroupOperationHandler()),mapReduce(new FindOperationHandler()) ;
+	group(new GroupOperationHandler()),mapReduce(new FindOperationHandler()),aggregate(new AggregateOperationHandler());
 	
 	MongoDBQueryOperationType(IOperationHandler handler)
 	{

--- a/projects/plugins/data_providers/mongodb-datasource-provider/src/main/resources/META-INF/documentation/queryEndpointHelp.html
+++ b/projects/plugins/data_providers/mongodb-datasource-provider/src/main/resources/META-INF/documentation/queryEndpointHelp.html
@@ -15,6 +15,7 @@ All queries must follow following syntax
   <li><a href="http://api.mongodb.org/java/current/com/mongodb/DBCollection.html#distinct(java.lang.String, com.mongodb.DBObject)">distinct</a></li>
   <li><a href="http://api.mongodb.org/java/current/com/mongodb/DBCollection.html#group(com.mongodb.DBObject, com.mongodb.DBObject, com.mongodb.DBObject, java.lang.String)">group</a></li>
   <li><a href="http://api.mongodb.org/java/current/com/mongodb/DBCollection.html#mapReduce(java.lang.String, java.lang.String, java.lang.String, com.mongodb.DBObject)">mapreduce</a></li>
+	<li><a href="https://mongodb.github.io/mongo-java-driver/3.6/javadoc/?com/mongodb/client/model/Aggregates.html">aggregate</a></li>
 </ul>
 </div>
 
@@ -87,6 +88,20 @@ All queries must follow following syntax
 							"map" : "function(){}" , 
 							"reduce" : "function(){}" , 
 							"outputCollection" : "outputcollection"    
+						}
+}
+</textarea>
+</div>
+
+<div>
+	<h5>aggregate</h5>
+	<textarea readonly="readonly">
+{
+	"_operation" : "aggregate" ,
+	"_operation_args" : {
+							"match" : { patientId: 'x' }  ,
+							"group" : { _id: "$age", total: { $sum: "$bill" } } ,
+							"sort" :  { total: -1 }
 						}
 }
 </textarea>


### PR DESCRIPTION
- Added the mongo aggregate support.
Supports aggregate query like this.
`db.orders.aggregate([ { $match: { status: "A" } }, { $group: { _id: "$cust_id", total: { $sum: "$amount" } } }, { $sort: { total: -1 } } ])`
Here is the corresponding Bindass template for above aggregate query.
`{ "_operation" : "aggregate" , "_operation_args" : { "match" : { status: "A" } , "group" : { _id: "$cust_id", total: { $sum: "$amount" } } , "sort" : { total: -1 } } }`

- Changed the Bindass web interface appropriately.
<img width="1440" alt="Screenshot 2020-02-18 at 21 25 02" src="https://user-images.githubusercontent.com/36238140/74754874-4c7d2d00-5298-11ea-8819-ffd3b269c403.png">
